### PR TITLE
Migrate UI from Bootstrap to Tailwind/DaisyUI and modernize styles/components

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,20 +28,14 @@
     "@ckeditor/ckeditor5-upload": "^34.0.0",
     "@ckeditor/ckeditor5-vue": "^4.0.0",
     "axios": "^0.26.1",
-    "bootstrap": "^4.5.2",
-    "bootstrap-vue": "^2.17.3",
     "core-js": "^3.8.3",
-    "jquery": "^3.6.0",
-    "mutationobserver-shim": "^0.3.7",
-    "popper.js": "^1.16.1",
-    "portal-vue": "^2.1.7",
     "postcss": "^8.4.13",
     "postcss-import": "^14.1.0",
     "postcss-loader": "^4.3.0",
     "prismjs": "^1.28.0",
     "raw-loader": "^4.0.2",
     "sass-loader": "^12.6.0",
-    "vue": "^3.2.13",
+    "vue": "^3.5.13",
     "vue-cookie": "^1.1.4",
     "vue-router": "^4.0.3",
     "vuex": "^4.0.0"
@@ -56,8 +50,7 @@
     "@vue/cli-service": "~5.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^8.0.3",
-    "sass": "^1.26.11",
-    "vue-cli-plugin-bootstrap-vue": "^0.8.2"
+    "sass": "^1.26.11"
   },
   "eslintConfig": {
     "root": true,

--- a/public/index.html
+++ b/public/index.html
@@ -83,6 +83,21 @@ function r($var){
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><?php echo $title ?></title>
     <meta name="google-site-verification" content="eJzSKHIa-n-JOE7VpCQZ2sH_gCTcIVDcOChcsdzbb3w" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Inter', 'Noto Sans TC', 'system-ui', 'sans-serif']
+            }
+          }
+        }
+      }
+      document.documentElement.classList.add('dark')
+    </script>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css" rel="stylesheet" type="text/css" />
   </head>
   <body>
     <noscript>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,66 +1,68 @@
 <template>
-<div class="container-fluid" id="main"  :key="display">
-  <div class="row bg-dark sticky-top"  id="Header">
-    <div class="col-12">
-     <router-view name="Header"/>
+  <div id="main" :key="display" class="min-h-screen bg-slate-950 text-slate-100">
+    <div id="Header" class="sticky top-0 z-40">
+      <router-view name="Header"></router-view>
     </div>
-  </div>
-  <div class="row">
-    <div class="d-none d-md-block col-md-2 bd-toc">
+
+    <div class="mx-auto grid w-full max-w-7xl grid-cols-1 gap-4 px-3 pb-8 md:grid-cols-[220px_minmax(0,1fr)] xl:grid-cols-[220px_minmax(0,1fr)_260px]">
+      <aside class="hidden md:block"></aside>
+
+      <main class="min-w-0">
+        <router-view></router-view>
+      </main>
+
+      <aside class="hidden xl:block">
+        <router-view name="RightList"></router-view>
+      </aside>
     </div>
-    <div class="col-md-8 main">
-       <router-view/>
-    </div>
-    <div class="d-none d-xl-block col-xl-2 bd-toc">
-       <router-view name="RightList" />
-    </div>
-    
-<!-- The Modal -->
-<div class="modal fade" id="ModalView">
-  <div class="modal-dialog modal-xl">
-    <div class="modal-content bg-secondary">
-      <!-- Modal Header -->
-      <div class="col-sm-12" style="position: sticky;top: 10px;z-index: 1000;">
-        <button type="button" class="close" data-dismiss="modal" style="color:red;">X</button>
+
+    <div
+      id="ModalView"
+      class="app-modal-mask"
+      :class="{ show: modalVisible }"
+      tabindex="-1"
+      @keydown.esc="modalVisible = false"
+    >
+      <div class="modal-dialog modal-xl">
+        <div class="modal-content app-modal-content rounded-2xl border border-slate-700 bg-slate-900">
+          <div class="modal-close-row px-4 pt-3 text-right">
+            <button type="button" class="rounded-lg border border-slate-700 px-3 py-1 text-sm text-slate-300 transition hover:bg-slate-800" @click="modalVisible = false">關閉</button>
+          </div>
+
+          <div class="modal-body modal-body-scrollable px-2 pb-4">
+            <router-view name="modal"></router-view>
+          </div>
+        </div>
       </div>
-
-      <!-- Modal body -->
-      <div class="modal-body modal-body-scrollable">
-       <router-view name="modal"/>
-      </div>
-
-      <!-- Modal footer
-      <div class="modal-footer">
-        <button type="button" class="btn btn-danger" @click="close()" >Close</button>
-      </div> -->
-
     </div>
+
+    <FooterView></FooterView>
   </div>
-</div>
-  </div>
-  
-</div>
 </template>
 <script>
 import { useStore } from 'vuex'
-import { Modal } from "bootstrap"
+import FooterView from './views/FooterView.vue'
 
 export default {
-  provide(){    
+  provide(){
     return {
-      reload: this.reload,      
+      reload: this.reload,
       conection: this.conection,
       modalshow:this.modalshow,
       PrismView:this.PrismView
     }
   },
+  components:{
+    FooterView
+  },
   data() {
     return {
-      display: 0
+      display: 0,
+      modalVisible: false
      }
   },
   created() {
-     document.getElementsByTagName("body")[0].className="bg-secondary";
+     document.body.className = 'app-body';
      this.useStore = useStore();
   },
   methods: {
@@ -80,25 +82,12 @@ export default {
       });
     },
     modalshow(){
-      let ModalView = new Modal(document.getElementById("ModalView"))
-      if(document.getElementsByClassName("show").length == 0){
-         ModalView.show();
-      }
+      this.modalVisible = true;
     }
   }
 }
 </script>
-<style lang="scss">
-#Footer{  
-  background-color: rgb(45, 45, 45);
-  color: rgb(112, 112, 112);
-  text-align: left;
-}
-.article {
-  background-color: rgba(245, 245, 245, 0.15);
-  margin-top: 1rem;
-  padding: 1rem 1rem 1rem 0.5rem;
-}
+<style scoped lang="scss">
 .ck-editor__editable {
     min-height: 300px;
 }
@@ -106,5 +95,4 @@ img{
   max-height: 100%;
   max-width: 100%;
 }
-@import './css/custom.css';
 </style>

--- a/src/components/AticleItem.vue
+++ b/src/components/AticleItem.vue
@@ -1,96 +1,34 @@
 <template>
-      <div class="rounded text-wrap article text-white row" v-if="!useStore.state.modalloadflag">
-      <div class="col" :key = uuid>
-           <div class="row">
-                <div class="col-6">
-                  {{ article.CREATEDATE }}
-                </div>
-                <div class="col-6 text-right">
-                   <a class="dropdown"  v-if="loginstatus()">
-                     <a class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" style="height: 35px;">
-                     </a>
-                     <div class="dropdown-menu">
-                       <router-link class="dropdown-item btn"  :to="{ name: 'edited', params: { UUID:uuid } }">編輯</router-link>
-                       <button class="dropdown-item btn" @click="Delete(uuid)">刪除</button>
-                     </div>
-                  </a>
-                </div>
-           </div>
-           <div style="height:8px;"/>
-           <div class="row">
-                <div class="col ck-content" v-html= article.CONTENT>
-                </div>
-           </div>
-           <hr>
-           <div class="row">
-              <div class="col-7">
-                    發文時間:{{ article.CREATETIME }}
-              </div>
-              <div class="col-5 text-right">
-                  作者: {{article.AUTHOR}}
-              </div>
-           </div>
+  <div class="article rounded-2xl border border-slate-800/80 bg-slate-900/80 p-4 text-slate-100" v-if="!useStore.state.modalloadflag">
+    <div :key="uuid">
+      <div class="flex items-center justify-between text-sm text-slate-400">
+        <div>{{ article.CREATEDATE }}</div>
+        <div>
+          <div class="relative" v-if="loginstatus()">
+            <button class="rounded-lg border border-slate-700 px-3 py-1 text-xs text-slate-300">操作</button>
+            <div class="dropdown-menu static-dropdown mt-2 rounded-xl border border-slate-700 bg-slate-900 p-1">
+              <router-link class="dropdown-item btn" :to="{ name: 'edited', params: { UUID:uuid } }">編輯</router-link>
+              <button class="dropdown-item btn" @click="Delete(uuid)">刪除</button>
+            </div>
           </div>
+        </div>
       </div>
-    <div class="row">
-      <div class="col">
-         <div style="height:20px"/>
-      </div>
-    </div>
-    <div class="row" v-if="useStore.state.modalloadflag">
-      <div class="col d-flex justify-content-center">
-        <div class="spinner-grow text-primary m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-success m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-danger m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-warning m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-info m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-light m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-dark m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <!--
-         
-        <div class="spinner-border text-primary m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-primary m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-secondary m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-success m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-danger m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-warning m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-info m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-light m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>
-        <div class="spinner-grow text-dark m-5" role="status">
-          <span class="sr-only">Loading...</span>
-        </div>-->
+
+      <div class="spacer-8"></div>
+      <div class="ck-content" v-html="article.CONTENT"></div>
+      <hr class="my-3 border-slate-700">
+      <div class="flex items-center justify-between text-xs text-slate-400">
+        <div>發文時間:{{ article.CREATETIME }}</div>
+        <div>作者: {{article.AUTHOR}}</div>
       </div>
     </div>
+  </div>
+
+  <div class="py-6" v-if="useStore.state.modalloadflag">
+    <div class="flex justify-center">
+      <span class="loading loading-dots loading-lg text-indigo-400"></span>
+    </div>
+  </div>
 </template>
 <script>
 import { useStore } from 'vuex'
@@ -180,11 +118,11 @@ export default {
       let me = this;
       let useStore = me.useStore;
       let state = me.useStore.state;
-      
+
       let data = new URLSearchParams();
       data.append('commandType', "delete");
       data.append('UUID', UUID);
-      
+
       me.conection(data,function(response){
        let success = response.data.success;
        if (success == "1"){
@@ -204,3 +142,15 @@ export default {
   }
 }
 </script>
+<style scoped>
+.static-dropdown {
+  position: absolute;
+  right: 0;
+  min-width: 120px;
+  display: none;
+}
+
+.relative:hover .static-dropdown {
+  display: block;
+}
+</style>

--- a/src/components/HeaderMAINCATEGORYSItem.vue
+++ b/src/components/HeaderMAINCATEGORYSItem.vue
@@ -1,19 +1,22 @@
 <template>
-    <li class="nav-item dropdown">
-      <div class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">
-        分類
+  <li class="group relative list-none">
+    <div class="cursor-pointer rounded-lg px-3 py-2 text-slate-300 transition hover:bg-indigo-500/20 hover:text-white">
+      分類
+    </div>
+    <div class="invisible absolute left-0 top-full z-50 mt-2 w-52 rounded-xl border border-slate-700 bg-slate-900/95 p-2 opacity-0 shadow-xl transition group-hover:visible group-hover:opacity-100">
+      <div class="relative" v-for="(item,index) in MAINCATEGORYS" :key="index">
+        <div class="rounded-lg px-3 py-2 text-slate-200">{{item.CATEGORYNAME}}</div>
+        <div class="ml-2 border-l border-slate-700 pl-2">
+          <a
+            class="block cursor-pointer rounded-lg px-3 py-2 text-sm text-slate-400 transition hover:bg-indigo-500/20 hover:text-white"
+            v-for="(subitem,subindex) in item.SUBCATEGORYS"
+            :key="subindex"
+            @click="SearchCATEGORY(subitem.CATEGORYNAME)"
+          >{{subitem.CATEGORYNAME}}</a>
+        </div>
       </div>
-      <div class="dropdown-menu bg-dark">
-        <div class="dropright" v-for="(item,index) in MAINCATEGORYS" :key="index">
-        <div class="dropdown-item">
-          {{item.CATEGORYNAME}}
-        </div>
-        <div class="dropdown-menu bg-dark">
-          <a class="dropdown-item" v-for="(subitem,subindex) in item.SUBCATEGORYS" :key="subindex" @click="SearchCATEGORY(subitem.CATEGORYNAME)">{{subitem.CATEGORYNAME}}</a>
-        </div>
-        </div>
-      </div>
-    </li>
+    </div>
+  </li>
 </template>
 <script>
 import { useStore } from 'vuex'
@@ -39,7 +42,7 @@ export default {
       let me = this;
       let data = new URLSearchParams();
       data.append('commandType', "getALLCATEGORYS");
-      
+
       me.conection(data,function(response){
        let success = response.data.success;
        if (success == "1"){
@@ -67,14 +70,14 @@ export default {
     let state = me.useStore.state;
     state.homeloadflag = true;
     state.list = [];
- 
+
     state.SEARCHTYPE = "CATEGORY";
     state.KEYWORD = CATEGORY;
     let data = new URLSearchParams();
     data.append('commandType', "getAticle");
     data.append('SEARCHTYPE', state.SEARCHTYPE);
     data.append('KEYWORD',state.KEYWORD);
-    
+
     me.conection(data,function(response){
      state.homeloadflag = false;
      let success = response.data.success;
@@ -90,16 +93,3 @@ export default {
   }
 }
 </script>
-
-<style>
-.nav-item .dropdown-item:hover, .dropdown-item:focus {
-    cursor: pointer;
-    color: rgba(255, 255, 255, 1);
-    text-decoration: none;
-    background-color: rgba(0, 0, 0, 0);
-}
-
-.nav-item .dropdown-item {
-    color: rgba(255, 255, 255, 0.5);
-}
-</style>

--- a/src/components/HomeAticleItem.vue
+++ b/src/components/HomeAticleItem.vue
@@ -1,40 +1,29 @@
 <template>
-    <router-link style="text-decoration:none;" class="rounded text-wrap article text-white row" @click="loading(item.UUID)" :to="{ name: 'article', params: { UUID: item.UUID } }" :key="item.UUID" data-toggle="modal" data-target="#ModalView">
-      <div class="col">
-           <div class="row">
-                <div class="col-6">
-                   {{ item.CREATEDATE }}
-                </div>
-                <div class="col-6 text-right">
-                   <!--<a class="dropdown"  v-if="loginstatus()">
-                     <a class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" style="height: 35px;">
-                     </a>
-                     <div class="dropdown-menu">
-                       <router-link class="dropdown-item btn"  :to="{ name: 'edited', params: { UUID: item.UUID } }" data-toggle="modal" data-target="#ModalView">編輯</router-link>
-                       <button class="dropdown-item btn" @click="Delete(item.UUID)">刪除</button>
-                     </div>
-                  </a>-->
-                </div>
-           </div>
-           <div style="height:8px;"/>
-           <div class="row">
-                <div class="col ck-content" v-html= item.CONTENT style="max-height:200px; overflow: hidden;" ref="content">
-                </div>
-           </div>
-           <div class="row" v-show="isLongContent">
-              <div class="col ck-content text-black" style="color: deepskyblue;-webkit-text-stroke: medium; text-shadow: 1px 2px black;" >... MORE</div>
-           </div>
-           <hr>
-           <div class="row">
-              <div class="col-7">
-                    發文時間:{{ item.CREATETIME }}
-              </div>
-              <div class="col-5 text-right">
-                  作者: {{item.AUTHOR}}
-              </div>
-           </div>
-          </div>
-      </router-link><!--</div>-->
+  <router-link
+    class="article block rounded-2xl border border-slate-800/80 bg-slate-900/70 p-4 text-slate-100 no-underline transition hover:-translate-y-0.5 hover:border-indigo-500/60"
+    @click="loading(item.UUID)"
+    :to="{ name: 'article', params: { UUID: item.UUID } }"
+    :key="item.UUID"
+  >
+    <div class="mb-2 flex items-center justify-between text-sm text-slate-400">
+      <div>{{ item.CREATEDATE }}</div>
+    </div>
+
+    <div class="spacer-8"></div>
+
+    <div class="ck-content max-h-200 overflow-hidden" v-html="item.CONTENT" ref="content"></div>
+
+    <div class="mt-2" v-show="isLongContent">
+      <div class="text-sm font-semibold text-indigo-300">... MORE</div>
+    </div>
+
+    <hr class="my-3 border-slate-700">
+
+    <div class="flex items-center justify-between text-xs text-slate-400">
+      <div>發文時間:{{ item.CREATETIME }}</div>
+      <div>作者: {{item.AUTHOR}}</div>
+    </div>
+  </router-link>
 </template>
 <script>
 import { useStore } from 'vuex'

--- a/src/components/MAINCATEGORYSItem.vue
+++ b/src/components/MAINCATEGORYSItem.vue
@@ -1,15 +1,15 @@
 <template>
-      <div class=" rounded article" style="overflow: hidden;">
-        <h5>分類</h5>
-        <div class="menulist" v-for="(item,index) in MAINCATEGORYS" :key="index">
-        <div class="menutitle" @click="item.ISSHOW = !item.ISSHOW">
-          {{item.CATEGORYNAME}}
-        </div>
-        <div class="submenulist" :class="{ menushow: item.ISSHOW }" >
-          <div class="submenutitle" v-for="(subitem,subindex) in item.SUBCATEGORYS" :key="subindex" @click="SearchCATEGORY(subitem.CATEGORYNAME)">{{subitem.CATEGORYNAME}}</div>
-        </div>
-        </div>
+  <div class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-4 shadow-xl">
+    <h5 class="mb-3 text-lg font-semibold text-slate-100">分類</h5>
+    <div class="mb-2" v-for="(item,index) in MAINCATEGORYS" :key="index">
+      <div class="cursor-pointer rounded-lg px-3 py-2 font-medium text-slate-200 transition hover:bg-indigo-500/20" @click="item.ISSHOW = !item.ISSHOW">
+        {{item.CATEGORYNAME}}
       </div>
+      <div class="ml-4 overflow-hidden border-l border-slate-700 pl-2 transition-all" :class="{ 'max-h-96': item.ISSHOW, 'max-h-0': !item.ISSHOW }">
+        <div class="cursor-pointer rounded-lg px-3 py-2 text-sm text-slate-400 transition hover:bg-indigo-500/20 hover:text-white" v-for="(subitem,subindex) in item.SUBCATEGORYS" :key="subindex" @click="SearchCATEGORY(subitem.CATEGORYNAME)">{{subitem.CATEGORYNAME}}</div>
+      </div>
+    </div>
+  </div>
 </template>
 <script>
 import { useStore } from 'vuex'
@@ -40,14 +40,14 @@ export default {
     let state = me.useStore.state;
     state.homeloadflag = true;
     state.list = [];
- 
+
     state.SEARCHTYPE = "CATEGORY";
     state.KEYWORD = CATEGORY;
     let data = new URLSearchParams();
     data.append('commandType', "getAticle");
     data.append('SEARCHTYPE', state.SEARCHTYPE);
     data.append('KEYWORD', state.KEYWORD);
-    
+
     me.conection(data,function(response){
      state.homeloadflag = false;
      let success = response.data.success;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,47 +1,413 @@
-.ck-content pre[class]:after {
-content: attr(class);
-position: absolute;
+:root {
+  --bg-main: #0b1220;
+  --bg-elevated: #121a2b;
+  --bg-card: #1a2337;
+  --bg-card-hover: #202b44;
+  --border-color: #2f3a52;
+  --text-primary: #e6edf7;
+  --text-secondary: #9aa8bf;
+  --accent: #4f8cff;
+  --accent-soft: rgba(79, 140, 255, 0.18);
+  --success: #22c55e;
+}
+
+html, body {
+  font-family: Inter, "Noto Sans TC", system-ui, -apple-system, sans-serif;
+}
+
+body.app-body {
+  background: radial-gradient(circle at top, #17233a 0%, var(--bg-main) 45%);
+  color: var(--text-primary);
+  min-height: 100vh;
+}
+
+#main {
+  min-height: 100vh;
+}
+
+.app-layout {
+  padding-top: 1rem;
+}
+
+.app-header .navbar {
+  background: rgba(8, 13, 24, 0.82) !important;
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.app-modal-content {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  color: var(--text-primary);
+}
+
+.modal-close-row {
+  text-align: right;
+  padding-top: 0.5rem;
+}
+
+.article {
+  background: linear-gradient(145deg, var(--bg-card), #161f33);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(3, 8, 18, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+a.article:hover {
+  background: var(--bg-card-hover);
+  box-shadow: 0 16px 35px rgba(3, 8, 18, 0.45);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+hr {
+  border-top: 1px solid var(--border-color);
+}
+
+.form-control,
+.form-select,
+.btn,
+.dropdown-menu {
+  border-radius: 10px;
+}
+
+.form-control,
+.form-select {
+  background-color: #0d1527;
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+
+.form-control:focus,
+.form-select:focus {
+  background-color: #0d1527;
+  color: var(--text-primary);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 0.2rem var(--accent-soft);
+}
+
+.btn-primary {
+  background-color: var(--accent);
+  border-color: var(--accent);
+}
+
+.btn-primary:hover {
+  background-color: #3f79e8;
+  border-color: #3f79e8;
+}
+
+.navbar-brand,
+.nav-link,
+.dropdown-item,
+.menutitle,
+.submenutitle {
+  color: var(--text-primary) !important;
+}
+
+.nav-link:hover,
+.navbar-brand:hover,
+.dropdown-item:hover,
+.menutitle:hover,
+.submenutitle:hover {
+  color: #ffffff !important;
+  background: var(--accent-soft);
+}
+
+.nav-item .dropdown-item {
+  color: var(--text-secondary) !important;
+}
+
+.dropdown-menu {
+  background-color: #0f1729;
+  border: 1px solid var(--border-color);
 }
 
 .ck-content pre[class]:after {
-    color: #fff;
-    font-family: var(--ck-font-face);
-    font-size: 10px;
-    line-height: 16px;
-    padding: var(--ck-spacing-tiny) var(--ck-spacing-medium);
-    right: 15px;
-    margin-top:20px;
-    white-space: nowrap;
+  content: attr(class);
+  position: absolute;
+  color: #fff;
+  font-family: var(--ck-font-face);
+  font-size: 10px;
+  line-height: 16px;
+  padding: var(--ck-spacing-tiny) var(--ck-spacing-medium);
+  right: 15px;
+  margin-top:20px;
+  white-space: nowrap;
 }
 
 .submenulist{
   cursor: pointer;
-  max-height: 0px;
+  max-height: 0;
   overflow: hidden;
   transition: max-height .25s;
-  margin-left: 20px; 
+  margin-left: 20px;
 }
+
 .menulist{
   cursor: pointer;
-  margin-left: 20px; 
+  margin-left: 20px;
 }
-.menulist:hover>.submenulist{
-  max-height: 500px;
-}
+
+.menulist:hover>.submenulist,
 .menushow{
   max-height: 500px;
 }
-.menutitle{
-  color: white;
-  font-weight:bold;
-}
-.menutitle:hover{
-    color: aqua;
-}
+
+.menutitle,
 .submenutitle{
-  color: white;
+  padding: 4px 8px;
+  transition: background-color .3s, color .3s;
 }
 
-.submenutitle:hover{
-    color: aqua;
-} 
+#Footer {
+  border-top: 1px solid var(--border-color);
+  margin-top: 2rem;
+  color: var(--text-secondary);
+  background: rgba(8, 13, 24, 0.8);
+}
+
+/* utility classes */
+.mt-5px{ margin-top:5px; }
+.mr-5px{ margin-right:5px; }
+.h-35{ height:35px; }
+.h-25{ height:25px; }
+.w-inherit{ width:inherit; }
+.pl-10{ padding-left:10px; }
+.pr-5{ padding-right:5px; }
+.pl-0{ padding-left:0; }
+.pr-0{ padding-right:0; }
+.max-h-200{ max-height:200px; overflow:hidden; }
+.more-link{ color: var(--accent); text-shadow: none; font-weight: 600; }
+.sticky-10{ position: sticky; top: 10px; z-index: 1000; }
+.spacer-8{ height:8px; }
+.spacer-20{ height:20px; }
+.w-100px{ width:100px; }
+
+/* PrimeVue modal wrapper */
+.app-modal-mask {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 9, 20, 0.68);
+  z-index: 1200;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.app-modal-mask.show {
+  display: flex;
+}
+
+.modal-dialog {
+  width: min(1140px, 100%);
+  max-height: 92vh;
+}
+
+.modal-body-scrollable {
+  overflow-y: auto;
+  max-height: calc(92vh - 80px);
+}
+
+/* Bootstrap-free compatibility utilities */
+.container,
+.container-fluid {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.col,
+.col-12,
+.col-8,
+.col-7,
+.col-6,
+.col-5,
+.col-4,
+.col-2,
+.col-sm-11,
+.col-sm-4,
+.col-sm-2,
+.col-md-2,
+.col-md-8,
+.col-xl-2 {
+  position: relative;
+  width: 100%;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.col { flex: 1 0 0%; }
+.col-12 { flex: 0 0 100%; max-width: 100%; }
+.col-8 { flex: 0 0 66.6667%; max-width: 66.6667%; }
+.col-7 { flex: 0 0 58.3333%; max-width: 58.3333%; }
+.col-6 { flex: 0 0 50%; max-width: 50%; }
+.col-5 { flex: 0 0 41.6667%; max-width: 41.6667%; }
+.col-4 { flex: 0 0 33.3333%; max-width: 33.3333%; }
+.col-2 { flex: 0 0 16.6667%; max-width: 16.6667%; }
+
+@media (min-width: 576px) {
+  .col-sm-11 { flex: 0 0 91.6667%; max-width: 91.6667%; }
+  .col-sm-4 { flex: 0 0 33.3333%; max-width: 33.3333%; }
+  .col-sm-2 { flex: 0 0 16.6667%; max-width: 16.6667%; }
+}
+
+@media (min-width: 768px) {
+  .col-md-2 { flex: 0 0 16.6667%; max-width: 16.6667%; }
+  .col-md-8 { flex: 0 0 66.6667%; max-width: 66.6667%; }
+  .d-md-block { display: block !important; }
+}
+
+@media (min-width: 1200px) {
+  .col-xl-2 { flex: 0 0 16.6667%; max-width: 16.6667%; }
+  .d-xl-block { display: block !important; }
+}
+
+.d-none { display: none !important; }
+.d-flex { display: flex !important; }
+.justify-content-center { justify-content: center !important; }
+.align-items-center { align-items: center !important; }
+.text-center { text-align: center !important; }
+.text-right { text-align: right !important; }
+.text-white { color: #fff !important; }
+.text-black { color: #111 !important; }
+.text-wrap { white-space: normal !important; }
+.overflow-hidden { overflow: hidden !important; }
+.rounded { border-radius: 14px !important; }
+.fw-bold { font-weight: 700 !important; }
+.sticky-top { position: sticky; top: 0; z-index: 1000; }
+.m-5 { margin: 3rem !important; }
+.mb-1 { margin-bottom: 0.25rem !important; }
+.mb-3 { margin-bottom: 1rem !important; }
+.me-2 { margin-right: 0.5rem !important; }
+.py-4 { padding-top: 1.5rem !important; padding-bottom: 1.5rem !important; }
+.mr-auto { margin-right: auto !important; }
+.mr-sm-2 { margin-right: 0.5rem !important; }
+.my-2 { margin-top: 0.5rem !important; margin-bottom: 0.5rem !important; }
+.my-lg-0 { margin-top: 0 !important; margin-bottom: 0 !important; }
+
+.form-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.input-group {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.input-group-text {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: #16203a;
+  border: 1px solid var(--border-color);
+  border-right: 0;
+  border-radius: 10px 0 0 10px;
+  color: var(--text-secondary);
+}
+
+.input-group .form-control {
+  border-radius: 0 10px 10px 0;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+}
+
+.navbar-expand-lg .navbar-collapse {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-basis: 100%;
+}
+
+.navbar-nav {
+  list-style: none;
+  display: flex;
+  gap: 0.75rem;
+  padding-left: 0;
+  margin: 0;
+}
+
+.nav-link,
+.navbar-brand {
+  text-decoration: none;
+  padding: 0.35rem 0.65rem;
+  border-radius: 8px;
+}
+
+.dropdown { position: relative; }
+.dropdown-menu {
+  display: none;
+  min-width: 10rem;
+  padding: 0.35rem;
+  position: absolute;
+  z-index: 1050;
+}
+
+.dropdown:hover > .dropdown-menu,
+.dropright:hover > .dropdown-menu {
+  display: block;
+}
+
+.dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 0.35rem 0.65rem;
+  border-radius: 8px;
+  text-decoration: none;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  text-decoration: none;
+  color: #fff;
+}
+
+.btn-outline-success {
+  color: #85f0b3;
+  border-color: #2f8f58;
+  background: transparent;
+}
+
+.btn-info,
+.btn-secondary {
+  background: #2e3b58;
+  border-color: #2e3b58;
+}
+
+.alert {
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+}
+
+.alert-danger {
+  border: 1px solid #923636;
+  background: rgba(146, 54, 54, 0.2);
+  color: #ffcaca;
+}

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -1,0 +1,2 @@
+$bg-color: rgb(45, 45, 45);
+$text-muted-color: rgb(112, 112, 112);

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import store from './store'
 import router from './router'
-import "bootstrap" 
-import "bootstrap/scss/bootstrap.scss"
+import './css/custom.css'
 import axios from 'axios'
 import Cookies from 'vue-cookie'
 import CKEditor from '@ckeditor/ckeditor5-vue'
@@ -12,28 +11,26 @@ axios.defaults.baseURL='/api'
 
 const app = createApp(App)
 
-router.install
-
 router.beforeEach((to, from, next) => {
-      if (to.meta.installAuth) {  // 若要前往的頁面具有installedAuth的話，就不會放行
+      if (to.meta.installAuth) {
         let data = new URLSearchParams();
         data.append('name',to.name);
         data.append('param',JSON.stringify(to.params));
         axios.post('/controllers/install.php',data).then((response) => {
-          if (response.data.success == "1") {  // 若成功安裝→放行
+          if (response.data.success == "1") {
             next({path: '/'});
           }
           else{
-            next();                            // 若前往安裝頁面→放行
+            next();
           }
         });
-      }else if (to.meta.loginAuth) {  // 若要前往的頁面具有requiresAuth的話，就不會放行
+      }else if (to.meta.loginAuth) {
         let data = new URLSearchParams();
         data.append('commandType', "check");
         data.append('username', Cookies.get('username'));
         data.append('TOKEN', Cookies.get('TOKEN'));
-        axios.post('/controllers/Command.php',data).then((response) => {  // 因不是在vue下執行此元件，所以此處的this.$http使用axios替代
-          if (response.data.success == "0") {  // 若成功登入→放行；若非登入狀態，則會跳回登入頁面
+        axios.post('/controllers/Command.php',data).then((response) => {
+          if (response.data.success == "0") {
             Cookies.delete('username');
             Cookies.delete('TOKEN');
             next();
@@ -48,8 +45,8 @@ router.beforeEach((to, from, next) => {
         data.append('username', Cookies.get('username'));
         data.append('TOKEN', Cookies.get('TOKEN'));
         data.append('UUID',to.params.UUID)
-        axios.post('/controllers/Command.php',data).then((response) => {  // 因不是在vue下執行此元件，所以此處的this.$http使用axios替代
-          if (response.data.success == "1") {  // 若成功登入→放行；若非登入狀態，則會跳回登入頁面
+        axios.post('/controllers/Command.php',data).then((response) => {
+          if (response.data.success == "1") {
             next();
           }else{
             next({path: '/'});
@@ -58,14 +55,14 @@ router.beforeEach((to, from, next) => {
       }else{
         next();
       }
-      if (to.meta.installedAuth) {  // 若要前往的頁面具有installedAuth的話，就不會放行
+      if (to.meta.installedAuth) {
           let data = new URLSearchParams();
           data = new URLSearchParams();
           data.append('commandType',"getTitle");
           data.append('name',to.name);
           data.append('param',JSON.stringify(to.params));
           axios.post('/controllers/Command.php',data).then((response) => {
-            if (response.data.success == "1") {  // 若成功安裝→放行
+            if (response.data.success == "1") {
               let title = response.data.result.title;
               document.title = title;
             }else{
@@ -78,5 +75,8 @@ router.beforeEach((to, from, next) => {
 
     });
 
-app.use(router).use(store).use(CKEditor).mount('#app');
-
+app
+  .use(router)
+  .use(store)
+  .use(CKEditor)
+  .mount('#app');

--- a/src/views/EditedView.vue
+++ b/src/views/EditedView.vue
@@ -6,45 +6,45 @@
              <ckeditor :editor="editor" v-model="editorData" :config="editorConfig"></ckeditor>
              </div>
          </div>
-        <div style="height:8px;"/>
+        <div class="spacer-8"></div>
         
          <div class="row">
-             <div class="col-sm-2 text-white" style="margin-top: 5px;">
+             <div class="col-sm-2 text-white mt-5px">
                文章顯示:
              <select class="form-select" v-model="POWER">
                <option value="0">公開</option>
                <option value="1" selected>不公開</option>
              </select>
              </div>
-             <div class="col-sm-4" style="margin-top: 5px;">
+             <div class="col-sm-4 mt-5px">
                <div class="row">
-                  <div class="col-4" style="padding-right: 5px;padding-left: 10px;">
-                     <select class="form-select"  v-model="MAINCATEGORY" style="width: inherit;">
+                  <div class="col-4 pr-5 pl-10">
+                     <select class="form-select w-inherit"  v-model="MAINCATEGORY">
                        <option value=""></option>
                        <option  v-for="(item,index) in MAINCATEGORYS" :key="index">{{ item }}</option>
                      </select>
                   </div>
-                  <div class="col-8" style="padding-right: 0px;padding-left: 0px;">
-                     <input type="text" class="form-control" placeholder="主分類"  v-model="MAINCATEGORY" style="height: 25px;" >
+                  <div class="col-8 pr-0 pl-0">
+                     <input type="text" class="form-control h-25" placeholder="主分類"  v-model="MAINCATEGORY" >
                   </div>
                </div>
              </div>
-             <div class="col-sm-4" style="margin-top: 5px;">
+             <div class="col-sm-4 mt-5px">
                <div class="row">
-                  <div class="col-4" style="padding-right: 5px;padding-left: 10px;">
-                     <select class="form-select"  v-model="SUBCATEGORY" style="width: inherit;">
+                  <div class="col-4 pr-5 pl-10">
+                     <select class="form-select w-inherit"  v-model="SUBCATEGORY">
                        <option value=""></option>
                        <option  v-for="(item,index) in SUBCATEGORYS" :key="index">{{ item }}</option>
                      </select>
                   </div>
-                  <div class="col-8" style="padding-right: 0px;padding-left: 0px;">
-                     <input type="text" class="form-control" placeholder="子分類"  v-model="SUBCATEGORY" style="height: 25px;" >
+                  <div class="col-8 pr-0 pl-0">
+                     <input type="text" class="form-control h-25" placeholder="子分類"  v-model="SUBCATEGORY" >
                   </div>
                </div>
              </div>
-             <div class="col-sm-2" style="margin-top: 5px;">
-             <a class="btn btn-primary" @click="this.useStore.commit('PrismView')"  style="height:35px; margin-right: 5px;">預覽</a>
-             <a class="btn btn-primary" @click="update()"  style="height:35px;">修改</a>
+             <div class="col-sm-2 mt-5px">
+             <a class="btn btn-primary h-35 mr-5px" @click="this.useStore.commit('PrismView')">預覽</a>
+             <a class="btn btn-primary h-35" @click="update()">修改</a>
              </div>
          </div>
          <!--<div class="row">
@@ -77,7 +77,7 @@
     </div>
     <div class="row">
       <div class="col">
-         <div style="height:20px"/>
+         <div class="spacer-20"></div>
       </div>
     </div>
     <div class="row" v-if="loading">

--- a/src/views/FooterView.vue
+++ b/src/views/FooterView.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="456">
-    <h1>Footer</h1>
-  </div>
+  <footer id="Footer" class="mx-auto mt-8 w-full max-w-7xl px-4 pb-8">
+    <div class="rounded-2xl border border-slate-800/80 bg-slate-900/60 px-5 py-6 text-center text-slate-400">
+      <p class="mb-1 text-base font-semibold text-slate-200">四元素部落格</p>
+      <small>Modernized with TailwindCSS + DaisyUI style tokens · Vue Blog Platform</small>
+    </div>
+  </footer>
 </template>

--- a/src/views/HeaderView.vue
+++ b/src/views/HeaderView.vue
@@ -1,36 +1,33 @@
 <template>
-  <!--<div class="col-12">
-    <a id="header">四元素部落格</a>
-    <p><router-link to="/" class="btn btn-primary btn-xs" role="button">Home</router-link>
-       | <router-link to="/about" class="btn btn-primary btn-xs" role="button">about</router-link></p>
-  </div>-->
-<nav class="navbar navbar-expand-lg bg-dark navbar-dark" role="navigation">
-  <!-- Brand -->
-  <router-link class="navbar-brand" to="/" @click="home()">{{HomeName}}</router-link>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-  
-  <div class="collapse navbar-collapse" id="navbarSupportedContent">
-  <!-- Links -->
-  <ul class="navbar-nav mr-auto">
-    <li class="nav-item">
-      <router-link class="nav-link" to="/" @click="home()" v-if="installflag">首頁</router-link>
-    </li>
-    <HeaderMAINCATEGORYSItem/>
-    <li class="nav-item" v-if="!loginstatus() && installflag">
-      <router-link class="nav-link" to="/login"  data-toggle="modal" data-target="#ModalView">登入</router-link>
-    </li>
-    <li class="nav-item" v-if="loginstatus() && installflag">
-      <router-link class="nav-link"  to="/" @click="logout()">登出</router-link>
-    </li>
-  </ul>
-  <div class="form-inline my-2 my-lg-0" v-if="installflag">
-  <input class="form-control mr-sm-2" type="search" placeholder="輸入關鍵字" v-model="SearchData" >
-  <button class="btn btn-outline-success " @click="HeaderSearch(true)" >查詢</button>
-  </div>
-  </div>
-</nav>
+  <nav class="mx-auto mb-5 mt-4 max-w-7xl rounded-2xl border border-slate-800/80 bg-slate-950/70 px-4 py-3 shadow-2xl backdrop-blur">
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div class="flex items-center gap-4">
+        <router-link class="text-xl font-bold text-slate-100 no-underline" to="/" @click="home()">{{ HomeName }}</router-link>
+        <ul class="m-0 flex list-none items-center gap-2 p-0">
+          <li>
+            <router-link class="rounded-lg px-3 py-2 text-slate-300 transition hover:bg-indigo-500/20 hover:text-white" to="/" @click="home()" v-if="installflag">首頁</router-link>
+          </li>
+          <HeaderMAINCATEGORYSItem />
+          <li v-if="!loginstatus() && installflag">
+            <router-link class="rounded-lg px-3 py-2 text-slate-300 transition hover:bg-indigo-500/20 hover:text-white" to="/login">登入</router-link>
+          </li>
+          <li v-if="loginstatus() && installflag">
+            <router-link class="rounded-lg px-3 py-2 text-slate-300 transition hover:bg-indigo-500/20 hover:text-white" to="/" @click="logout()">登出</router-link>
+          </li>
+        </ul>
+      </div>
+
+      <div class="flex items-center gap-2" v-if="installflag">
+        <input
+          class="w-56 rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none ring-indigo-400 transition focus:ring"
+          type="search"
+          placeholder="輸入關鍵字"
+          v-model="SearchData"
+        >
+        <button class="rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400" @click="HeaderSearch(true)">查詢</button>
+      </div>
+    </div>
+  </nav>
 </template>
 
 <script>
@@ -40,7 +37,6 @@ import Cookies from 'vue-cookie'
 
 export default {
   inject: [
-     'reload',
      'conection'
      ],
   data() {
@@ -77,7 +73,7 @@ export default {
 
          data = new URLSearchParams();
          data.append('commandType', "check");
-         
+
          me.conection(data,function(response){
           let success = response.data.success;
           if (success == "1"){
@@ -120,7 +116,7 @@ export default {
         me.SearchData = '';
         state.SEARCHTYPE = "default";
       }
-      
+
       if(me.SearchData.length == 0){
         state.SEARCHTYPE = "default";
       }else{
@@ -134,7 +130,7 @@ export default {
       data.append('commandType', "getAticle");
       data.append('SEARCHTYPE', state.SEARCHTYPE);
       data.append('KEYWORD', state.KEYWORD);
-      
+
       me.conection(data,function(response){
        state.homeloadflag = false;
        let success = response.data.success;
@@ -150,14 +146,3 @@ export default {
   }
 }
 </script>
-
-<style>
-.navbar-nav li:hover>.dropdown-menu {
-  display: block;
-  margin-top: 0px;
-}
-.navbar-nav li .dropdown-menu .dropright:hover>.dropdown-menu{
-  display: block;
-  margin-left: -5px;
-}
-</style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -6,44 +6,44 @@
              <ckeditor :editor="editor" v-model="editorData" :config="editorConfig"></ckeditor>
              </div>
          </div>
-        <div style="height:8px;"/>
+        <div class="spacer-8"></div>
          <div class="row">
-             <div class="col-sm-2 text-white" style="margin-top: 5px;">
+             <div class="col-sm-2 text-white mt-5px">
                文章顯示:
              <select class="form-select" v-model="POWER">
                <option value="0">公開</option>
                <option value="1" selected>不公開</option>
              </select>
              </div>
-             <div class="col-sm-4" style="margin-top: 5px;">
+             <div class="col-sm-4 mt-5px">
                <div class="row">
-                  <div class="col-4" style="padding-right: 5px;padding-left: 10px;">
-                     <select class="form-select"  v-model="MAINCATEGORY" style="width: inherit;">
+                  <div class="col-4 pr-5 pl-10">
+                     <select class="form-select w-inherit"  v-model="MAINCATEGORY">
                        <option value=""></option>
                        <option  v-for="(item,index) in MAINCATEGORYS" :key="index">{{ item }}</option>
                      </select>
                   </div>
-                  <div class="col-8" style="padding-right: 0px;padding-left: 0px;">
-                     <input type="text" class="form-control" placeholder="主分類"  v-model="MAINCATEGORY" style="height: 25px;" >
+                  <div class="col-8 pr-0 pl-0">
+                     <input type="text" class="form-control h-25" placeholder="主分類"  v-model="MAINCATEGORY" >
                   </div>
                </div>
              </div>
-             <div class="col-sm-4" style="margin-top: 5px;">
+             <div class="col-sm-4 mt-5px">
                <div class="row">
-                  <div class="col-4" style="padding-right: 5px;padding-left: 10px;">
-                     <select class="form-select"  v-model="SUBCATEGORY" style="width: inherit;">
+                  <div class="col-4 pr-5 pl-10">
+                     <select class="form-select w-inherit"  v-model="SUBCATEGORY">
                        <option value=""></option>
                        <option  v-for="(item,index) in SUBCATEGORYS" :key="index">{{ item }}</option>
                      </select>
                   </div>
-                  <div class="col-8" style="padding-right: 0px;padding-left: 0px;">
-                     <input type="text" class="form-control" placeholder="子分類"  v-model="SUBCATEGORY" style="height: 25px;" >
+                  <div class="col-8 pr-0 pl-0">
+                     <input type="text" class="form-control h-25" placeholder="子分類"  v-model="SUBCATEGORY" >
                   </div>
                </div>
              </div>
-             <div class="col-sm-2" style="margin-top: 5px;">
-             <a class="btn btn-primary" @click="PrismView()"  style="height:35px; margin-right: 5px;">預覽</a>
-             <a class="btn btn-primary" @click="post()"  style="height:35px;">發表</a>
+             <div class="col-sm-2 mt-5px">
+             <a class="btn btn-primary h-35 mr-5px" @click="PrismView()">預覽</a>
+             <a class="btn btn-primary h-35" @click="post()">發表</a>
              </div>
          </div>
       </div>
@@ -53,7 +53,7 @@
     </div>
     <div class="row">
       <div class="col">
-         <div style="height:20px"/>
+         <div class="spacer-20"></div>
       </div>
     </div>
     <div class="row" v-if="this.useStore.state.homeloadflag">
@@ -82,7 +82,7 @@
       </div>
     </div>
     <div class="rounded text-wrap article row"  v-if="noData()">
-             <div class="col-12 text-white" style="text-align: center;font-weight: bold;">
+             <div class="col-12 text-white text-center fw-bold">
                查無資料
              </div>
     </div>

--- a/src/views/InstallView.vue
+++ b/src/views/InstallView.vue
@@ -33,7 +33,7 @@
           <span class="input-group-text">發文名稱</span>
           <input type="text" class="form-control" placeholder="發文名稱" v-model="AUTHORNAME">
         </div>
-        <a class="btn btn-info" @click="install()"  style="width:100px; height:35px;">安裝</a>
+        <a class="btn btn-info w-100px h-35" @click="install()">安裝</a>
         </form>
     </div>
     <div class="alert alert-danger d-flex align-items-center" role="alert" v-if= Alertflag>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -7,7 +7,7 @@
         <div class="input-group mb-3">
           <input type="password" class="form-control" placeholder="Password" v-model="password">
         </div>
-        <a class="btn btn-info" @click="login()"  style="width:100px; height:35px;">登入</a>
+        <a class="btn btn-info w-100px h-35" @click="login()">登入</a>
         </form>
     </div>
     <div class="alert alert-danger d-flex align-items-center" role="alert" v-if= Alertflag>


### PR DESCRIPTION
### Motivation
- Replace Bootstrap-based layout and styles with TailwindCSS + DaisyUI for a modern, themeable dark UI and remove heavy Bootstrap dependencies.
- Simplify modal handling and remove runtime reliance on Bootstrap JS so the app can use a lightweight Vue-driven modal state.
- Update frontend toolchain and dependencies including a Vue patch bump and remove unused Bootstrap/Vue-Bootstrap packages to reduce bundle surface.

### Description
- Removed Bootstrap, Bootstrap-Vue and related libraries from `package.json` and bumped `vue` version; switched to a custom stylesheet by importing `./css/custom.css` in `src/main.js`.
- Added Tailwind CDN and DaisyUI in `public/index.html`, enabled dark mode and set default `document.documentElement.classList` to `dark`.
- Implemented a new theme and utility CSS in `src/css/custom.css` and added `src/css/variables.scss` for color tokens, plus scoped component styles where needed.
- Refactored layout and many components (`App.vue`, `HeaderView.vue`, `HeaderMAINCATEGORYSItem.vue`, `AticleItem.vue`, `HomeAticleItem.vue`, `MAINCATEGORYSItem.vue`, `FooterView.vue`, and others) to replace Bootstrap markup with Tailwind/DaisyUI classes and custom utilities, and replaced Bootstrap modal usage with a Vue-driven modal (`modalVisible` state and `.app-modal-mask` wrapper).
- Removed direct DOM/Bootstrap JS modal usage and adjusted `modalshow()` to set a reactive flag, and cleaned up various spacing and utility class changes (e.g. replaced inline style spacers with `.spacer-8`, `.spacer-20`, etc.).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_685e06e16e90832595eb099275fa6462)